### PR TITLE
Added Makefiles

### DIFF
--- a/CLibExtensions/makefile
+++ b/CLibExtensions/makefile
@@ -1,0 +1,31 @@
+# Makefile for CLibraryExtensions
+
+# Include paths.
+INC = -Iinclude
+
+# Compiler variables.
+CC = gcc
+CFLAGS = -std=c99 $(INC)
+
+# The main folders.
+SRC_PATH = src/
+OBJ_PATH = obj/
+LIB_PATH = lib/
+
+# Variables
+OBJECTS := $(OBJ_PATH)Vector.o $(OBJ_PATH)Stack.o $(OBJ_PATH)LinkedList.o $(OBJ_PATH)HashTable.o $(OBJ_PATH)UtilityFunctions.o
+
+# Compile the object files into a static library.
+
+$(LIB_PATH)libCExtensions.a: $(OBJECTS)
+	@mkdir -p $(LIB_PATH) # Create the library directory if it doesn't currently exist.
+	ar rcs $(LIB_PATH)libCExtensions.a $(OBJECTS)
+
+# Compile the source files into object files.
+
+$(OBJ_PATH)%.o : $(SRC_PATH)%.c
+	@mkdir -p $(OBJ_PATH) # Create the object directory if it doesn't currently exist. Note that the "-lm" includes the math library.
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -rf $(OBJ_PATH) $(LIB_PATH)

--- a/Scheduler/makefile
+++ b/Scheduler/makefile
@@ -1,0 +1,35 @@
+# Makefile for Scheduler
+
+# Include and library paths. Scheduler is dependent on CLibExtensions.
+INC = -I../CLibExtensions/include
+LIB = -L../CLibExtensions/lib
+
+# Compiler variables.
+CC = gcc
+CFLAGS = -std=c99 $(INC)
+CFLAGS_LINK = -static
+
+# Other variables.
+BINARY_NAME = Scheduler
+LIBRARIES = CExtensions
+OBJ_PATH = obj/
+BIN_PATH = bin/
+OBJECTS = $(OBJ_PATH)Lexer.o $(OBJ_PATH)Scanner.o $(OBJ_PATH)ScheduleFile.o $(OBJ_PATH)main.o
+
+# Command line variables.
+ifdef PRINT_PROCESSES_DATA
+	CFLAGS += -DPRINT_PROCESSES_DATA
+endif
+
+# Compile the object files into an executable file.
+$(BIN_PATH)$(BINARY_NAME) : $(OBJECTS)
+	@mkdir -p $(BIN_PATH) # Create the binary directory if it doesn't currently exist.
+	$(CC) $(CFLAGS_LINK) $(LIB) $(OBJECTS) -l$(LIBRARIES) -lm -o $(BIN_PATH)$(BINARY_NAME)
+
+# Compile the source files into object files.
+$(OBJ_PATH)%.o : %.c
+	@mkdir -p $(OBJ_PATH) # Create the object directory if it doesn't currently exist.	
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -rf $(OBJ_PATH) $(BIN_PATH)

--- a/makefile
+++ b/makefile
@@ -1,0 +1,30 @@
+# Makefile for our COP4600 assignments.
+
+# Compile variables.
+CC = gcc
+CFLAGS = -std=c99
+
+# The paths to the various parts of the overall "solution"
+CLIBEXT_PATH = CLibExtensions/
+SCHEDULER_PATH = Scheduler/
+OS_BIN_PATH = Output/
+
+# Move the executables into the COP4600 root directory.
+OS: SCHEDULER CLIB
+	mkdir -p $(OS_BIN_PATH)
+	echo "Copying Scheduler into output folder."
+	cp -r $(SCHEDULER_PATH)bin/* $(OS_BIN_PATH)
+
+# Compile the Scheduler project.
+SCHEDULER: CLIB
+	echo "Compiling the Scheduler project."
+	$(MAKE) -C $(SCHEDULER_PATH)
+
+# Compile the CLibraryExtensions library. It is needed by other executables.
+CLIB:
+	echo "Compiling the C Library Extensions library."
+	$(MAKE) -C $(CLIBEXT_PATH)
+
+clean:
+	$(MAKE) -C $(CLIBEXT_PATH) clean
+	$(MAKE) -C $(SCHEDULER_PATH) clean


### PR DESCRIPTION
Created makefiles for the overall project, the CLibExtensions project, and the Scheduler project. This fixes #2.

You can do the following with the makefiles.

- Run `make` in the CLibExtensions folder or the Scheduler folder to build these things.
- Run `make` in the root folder to compile everything and put the output in an `Output` folder.
- Run `make clean` to delete all intermediate and binary files generated from running make.
- Run `make PRINT_PROCESSES_DATA=true` from the root folder or the Scheduler folder to make the Scheduler print the data it reads in before executing the rest of main.