### PR TITLE
Fix For Parser Sometimes Getting Thrown Off By Comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,12 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
+
+# VS Code User Settings.
+.vscode
+
+# Other output
+Output/
+obj/
+lib/
+bin/

--- a/Scheduler/Lexer.c
+++ b/Scheduler/Lexer.c
@@ -151,19 +151,6 @@ Vector* LexerGetTokens(Lexer* lexer)
         return NULL;
     }
 
-    for (unsigned int i = 0; i < VectorCount(copyVector); i++)
-    {
-        LexerToken* token = VectorGet(i, copyVector);
-        if (token->tokenType == Number)
-        {
-            printf("Token %i, '%i'\n", i + 1, token->numTokenValue);
-        }
-        else if (token->tokenType == String)
-        {
-            printf("Token %i, '%s'\n", i + 1, token->strTokenValue);
-        }
-    }
-
     // Return the copy.
     return copyVector;
 }

--- a/Scheduler/Lexer.c
+++ b/Scheduler/Lexer.c
@@ -151,6 +151,19 @@ Vector* LexerGetTokens(Lexer* lexer)
         return NULL;
     }
 
+    for (unsigned int i = 0; i < VectorCount(copyVector); i++)
+    {
+        LexerToken* token = VectorGet(i, copyVector);
+        if (token->tokenType == Number)
+        {
+            printf("Token %i, '%i'\n", i + 1, token->numTokenValue);
+        }
+        else if (token->tokenType == String)
+        {
+            printf("Token %i, '%s'\n", i + 1, token->strTokenValue);
+        }
+    }
+
     // Return the copy.
     return copyVector;
 }

--- a/Scheduler/Scanner.c
+++ b/Scheduler/Scanner.c
@@ -92,7 +92,7 @@ void ScannerReadNextString(char** strStart, unsigned int* strLength, Scanner* sc
     *strStart = scan->fileContents + scan->currentPos;
 
     // Move the scanner forward until a whitespace character is found, or the end of the file is reached.
-    while (!ScannerIsAtEnd(scan) && !isspace(scan->fileContents[scan->currentPos]))
+    while (!ScannerIsAtEnd(scan) && isalnum(scan->fileContents[scan->currentPos]))
     {
         length++;
         ScannerMoveForward(scan);

--- a/Scheduler/Scanner.c
+++ b/Scheduler/Scanner.c
@@ -133,9 +133,6 @@ void ScannerMoveToNextLine(Scanner* scan)
     {
         ScannerMoveForward(scan);
     }
-
-    // Move the scanner forward once more to consume the new line character and be on the next line.
-    ScannerMoveForward(scan);
 }
 
 CharType ScannerGetCharType(Scanner* scan)


### PR DESCRIPTION
This pull request is to fix #6, where the parser could sometimes be thrown off by comments. This also adds folders used for object files, binaries, and VS Code to the `.gitignore` file.

I did some more testing with comments and whitespace, and it seems like the parser handles things properly now. Feel free to verify this with funky files that are _still technically correct_. I don't think my parser code handles all invalid file cases smoothly, so I'll be emailing the professor to ask if he plans on using invalid test files.