### PR TITLE
Implemented Sorting in ScheduleFile Loader

### DIFF
--- a/CLibExtensions/include/CLib/CLibraryExtensions.h
+++ b/CLibExtensions/include/CLib/CLibraryExtensions.h
@@ -24,7 +24,7 @@ typedef bool EqualsFunction(const void* obj1, const void* obj2);
 
 // A CompareTo Function type that can be used to compare two objects, determining if they are
 // equal, one is less than the other, or one is greater than the other.
-typedef int ComapreToFunction(const void* obj1, const void* obj2);
+typedef int CompareToFunction(const void* obj1, const void* obj2);
 
 // An implementation for the Equals function that compares two characters to each other.
 CLIBRARY_API bool CharacterEquals(const void* obj1, const void* obj2);

--- a/CLibExtensions/include/CLib/Vector.h
+++ b/CLibExtensions/include/CLib/Vector.h
@@ -13,7 +13,7 @@ typedef struct tagVector Vector;
 
 // Creates a new vector object, allocating an initial size.
 CLIBRARY_API bool VectorCreate(unsigned int dataTypeSize, unsigned int initialCapacity, unsigned int maxCapacity,
-	EqualsFunction* equalImpl, Vector** vect);
+							   EqualsFunction* equalsImpl, CompareToFunction* compareImpl, Vector** vect);
 
 // Destroys a vector object.
 CLIBRARY_API void VectorDestroy(Vector** vect);
@@ -61,3 +61,7 @@ CLIBRARY_API void VectorClear(Vector* vect);
 // Copies all the contents of the vector "vect" to the end of the vector "vectOther".
 // Note this copies only the used part of the data, not any unused parts of data.
 CLIBRARY_API bool VectorCopy(Vector* vectOther, Vector* vect);
+
+// Sorts the items in a vector. This requires a pointer to an appropriate "CompareTo" method implementation
+// to have been set.
+CLIBRARY_API void VectorSort(Vector* vect);

--- a/CLibExtensions/include/CLib/Vector.h
+++ b/CLibExtensions/include/CLib/Vector.h
@@ -12,8 +12,8 @@
 typedef struct tagVector Vector;
 
 // Creates a new vector object, allocating an initial size.
-CLIBRARY_API bool VectorCreate(unsigned int dataTypeSize, unsigned int initialCapacity, unsigned int maxCapacity,
-							   EqualsFunction* equalsImpl, CompareToFunction* compareImpl, Vector** vect);
+CLIBRARY_API bool VectorCreate(unsigned int dataTypeSize, unsigned int initialCapacity,
+    unsigned int maxCapacity, EqualsFunction* equalsImpl, CompareToFunction* compareImpl, Vector** vect);
 
 // Destroys a vector object.
 CLIBRARY_API void VectorDestroy(Vector** vect);

--- a/CLibExtensions/src/HashTable.c
+++ b/CLibExtensions/src/HashTable.c
@@ -359,7 +359,7 @@ void HashTableRehash(HashTable* hash)
 	// then insert them into a vector for temporary storage. This vector will just store the pointers (so essentially
 	// numbers) for each HashTableItem, instead of the item itself.
 	Vector* hashTableItems;
-	VectorCreate(sizeof(uintptr_t), hash->numItems, hash->numItems, NULL, &hashTableItems);
+	VectorCreate(sizeof(uintptr_t), hash->numItems, hash->numItems, NULL, NULL, &hashTableItems);
 
 	for(int i = 0; i < oldArrayLength; i++)
 	{

--- a/CLibExtensions/src/Stack.c
+++ b/CLibExtensions/src/Stack.c
@@ -23,7 +23,7 @@ bool StackCreate(int dataTypeSize, int initialCapacity, int maxStackSize, Stack*
 
 	// Instantiate the underlying vector.
 	initialCapacity = initialCapacity <= 0 ? DEFAULT_STACK_INITIAL_CAPACITY : initialCapacity;
-	if (!VectorCreate(dataTypeSize, initialCapacity, maxStackSize, NULL, &(*stackObj)->vect))
+	if (!VectorCreate(dataTypeSize, initialCapacity, maxStackSize, NULL, NULL, &(*stackObj)->vect))
 	{
 		free(*stackObj);
 		*stackObj = NULL;

--- a/Scheduler/Lexer.c
+++ b/Scheduler/Lexer.c
@@ -30,7 +30,7 @@ bool LexerCreate(Lexer** lexer)
         return false;
 
     // Instantiate the vector.
-    if (!VectorCreate(sizeof(LexerToken), 50, 0, NULL, &(*lexer)->tokens))
+    if (!VectorCreate(sizeof(LexerToken), 50, 0, NULL, NULL, &(*lexer)->tokens))
     {
         free(*lexer);
         return false;
@@ -139,7 +139,7 @@ bool LexerParseFile(const char* filename, Lexer* lexer)
 Vector* LexerGetTokens(Lexer* lexer)
 {
     Vector* copyVector;
-    if (!VectorCreate(sizeof(LexerToken), VectorCount(lexer->tokens), 0, NULL, &copyVector))
+    if (!VectorCreate(sizeof(LexerToken), VectorCount(lexer->tokens), 0, NULL, NULL, &copyVector))
     {
         return NULL;
     }

--- a/Scheduler/ScheduleFile.c
+++ b/Scheduler/ScheduleFile.c
@@ -8,6 +8,25 @@
 #include <stdlib.h>
 #include <string.h>
 
+int ProcessArrivalCompareTo(const void* obj1, const void* obj2)
+{
+    InputProcess* process1 = (InputProcess*)obj1;
+    InputProcess* process2 = (InputProcess*)obj2;
+
+    // Compare the arrival times of the processes.
+    if (process1->arrivalTime < process2->arrivalTime)
+    {
+        return -1;
+    }
+    else if (process1->arrivalTime > process2->arrivalTime)
+    {
+        return 1;
+    }
+
+    // If they have the same arrival time, compare the names of the processes.
+    return strcmp(process1->processName, process2->processName);
+}
+
 // Once a process line is identified, this will handle the tokens that make
 // up a process line, returning false if any of the tokens are invalid. The main
 // code should have the currentTokenIndex positioned on "process".
@@ -117,7 +136,10 @@ bool ReadScheduleFile(ScheduleData* fileData)
             }
 
             // Using the number of expected processes, initialize the vector of processes to contain them all.
-            if (!VectorCreate(sizeof(InputProcess), currentToken->numTokenValue, 0, NULL, &fileData->processes))
+            // We also provide a compare to callback so this vector can be sorted by the order that processes
+            // arrive.
+            if (!VectorCreate(sizeof(InputProcess), currentToken->numTokenValue, 0, NULL, ProcessArrivalCompareTo,
+                              &fileData->processes))
             {
                 fprintf(stderr, "Failed to initialize a vector to contain the input processes.\n");
                 readSuccessful = false;
@@ -223,6 +245,9 @@ bool ReadScheduleFile(ScheduleData* fileData)
 
     // Destroy the lexer.
     LexerDestroy(&lexer);
+
+    // Finally, with the processes all read in, sort them so earliest arrivals come in first.
+    VectorSort(fileData->processes);
 
     return readSuccessful;
 }


### PR DESCRIPTION
Implemented sorting in Vectors, where the use of the CompareTo function is required. Used this new functionality to allow the ScheduleFile loader to sort the processes by arrival time.

This requirement was identified in #4  when I realized @Areax's algorithm won't work when the processes specified in the file are not specified with their arrival times in order. In fact, none of the algorithm implementations would work without first sorting the processes by arrival time. This should fix that issue without the need to worry about sorting data within the algorithms. This will guarantee to the algorithms that the data is in order of arrival time.