### PR TITLE
Assignment 2 - Project Makefile, Circular Buffer and Circular Buffer Tests

### DIFF
--- a/BufferDriver/CircularBuffer.c
+++ b/BufferDriver/CircularBuffer.c
@@ -1,4 +1,3 @@
-
 /**
  * @file CircularBuffer.c
  */
@@ -6,8 +5,9 @@
 #include "CircularBuffer.h"
 #include <assert.h>
 #include <stdlib.h>
+#include <string.h>
 
-bool circular_buffer_create(CircularBuffer* circBuffer)
+bool CircularBufferCreate(CircularBuffer* circBuffer)
 {
 	assert(circBuffer != NULL);
 
@@ -17,13 +17,13 @@ bool circular_buffer_create(CircularBuffer* circBuffer)
 	return true;
 }
 
-void circular_buffer_clear(CircularBuffer* circBuffer)
+void CircularBufferClear(CircularBuffer* circBuffer)
 {
 	circBuffer->head = circBuffer->tail = 0;
 	circBuffer->isFull = false;
 }
 
-void circular_buffer_add_byte(unsigned char byte, CircularBuffer* circBuffer)
+void CircularBufferAddByte(unsigned char byte, CircularBuffer* circBuffer)
 {
 	assert(circBuffer != NULL);
 
@@ -40,12 +40,12 @@ void circular_buffer_add_byte(unsigned char byte, CircularBuffer* circBuffer)
 	}
 }
 
-unsigned char circular_buffer_get_byte(CircularBuffer* circBuffer)
+unsigned char CircularBufferGetByte(CircularBuffer* circBuffer)
 {
 	assert(circBuffer != NULL);
 
 	// Must not attempt to get a byte when the buffer is empty.
-	assert(!circular_buffer_is_empty(circBuffer));
+	assert(!CircularBufferIsEmpty(circBuffer));
 
 	// Get the byte to return.
 	unsigned char byte = circBuffer->buffer[circBuffer->tail];
@@ -60,7 +60,7 @@ unsigned char circular_buffer_get_byte(CircularBuffer* circBuffer)
 	return byte;
 }
 
-unsigned short circular_buffer_count(CircularBuffer* circBuffer)
+unsigned short CircularBufferCount(CircularBuffer* circBuffer)
 {
 	assert(circBuffer != NULL);
 
@@ -87,7 +87,7 @@ unsigned short circular_buffer_count(CircularBuffer* circBuffer)
 	return 0;
 }
 
-bool circular_buffer_is_empty(CircularBuffer* circBuffer)
+bool CircularBufferIsEmpty(CircularBuffer* circBuffer)
 {
 	assert(circBuffer != NULL);
 
@@ -99,7 +99,7 @@ bool circular_buffer_is_empty(CircularBuffer* circBuffer)
 	return false;
 }
 
-bool circular_buffer_is_full(CircularBuffer* circBuffer)
+bool CircularBufferIsFull(CircularBuffer* circBuffer)
 {
 	assert(circBuffer != NULL);
 

--- a/BufferDriver/CircularBuffer.c
+++ b/BufferDriver/CircularBuffer.c
@@ -1,0 +1,107 @@
+
+/**
+ * @file CircularBuffer.c
+ */
+
+#include "CircularBuffer.h"
+#include <assert.h>
+#include <stdlib.h>
+
+bool circular_buffer_create(CircularBuffer* circBuffer)
+{
+	assert(circBuffer != NULL);
+
+	// First, reset the CircularBuffer object so all values are zeroed.
+	memset(circBuffer, 0, sizeof(CircularBuffer));
+
+	return true;
+}
+
+void circular_buffer_clear(CircularBuffer* circBuffer)
+{
+	circBuffer->head = circBuffer->tail = 0;
+	circBuffer->isFull = false;
+}
+
+void circular_buffer_add_byte(unsigned char byte, CircularBuffer* circBuffer)
+{
+	assert(circBuffer != NULL);
+
+	// Add in the new byte.
+	circBuffer->buffer[circBuffer->head] = byte;
+
+	// Move the head forward, wrapping to the front if necessary.
+	circBuffer->head = (circBuffer->head + 1) % CIRCULAR_BUFFER_CAPACITY_BYTES;
+
+	// If the head coincides with the tail, the buffer has become full.
+	if (circBuffer->head == circBuffer->tail)
+	{
+		circBuffer->isFull = true;
+	}
+}
+
+unsigned char circular_buffer_get_byte(CircularBuffer* circBuffer)
+{
+	assert(circBuffer != NULL);
+
+	// Must not attempt to get a byte when the buffer is empty.
+	assert(!circular_buffer_is_empty(circBuffer));
+
+	// Get the byte to return.
+	unsigned char byte = circBuffer->buffer[circBuffer->tail];
+
+	// Move the tail forward, wrapping around if necessary.
+	circBuffer->tail = (circBuffer->tail + 1) % CIRCULAR_BUFFER_CAPACITY_BYTES;
+
+	// If the buffer was full, it isn't anymore.
+	circBuffer->isFull = false;
+
+	// Return the retrieved byte.
+	return byte;
+}
+
+unsigned short circular_buffer_count(CircularBuffer* circBuffer)
+{
+	assert(circBuffer != NULL);
+
+	// Return the amount of data that is available.
+	if (circBuffer->head > circBuffer->tail)
+	{
+		// If head > tail, we return head - tail so we get the amount of data between the two variables.
+		return circBuffer->head - circBuffer->tail;
+	}
+	else if (circBuffer->tail > circBuffer->head)
+	{
+		// If tail > head, the data has wrapped around the array. We want the data after tail to the end of the array, and
+		// then the data from the beginning of the array to head.
+		return CIRCULAR_BUFFER_CAPACITY_BYTES - circBuffer->tail + circBuffer->head;
+	}
+	else
+	{
+		// The buffer is either full or empty.
+		return circBuffer->isFull ? CIRCULAR_BUFFER_CAPACITY_BYTES : 0;
+	}
+
+	// Unnecessary return to remove GCC warning about control reaching end of non-void function. It's not actually
+	// possible to reac this part of the function.
+	return 0;
+}
+
+bool circular_buffer_is_empty(CircularBuffer* circBuffer)
+{
+	assert(circBuffer != NULL);
+
+	if (circBuffer->head == circBuffer->tail && circBuffer->isFull == false)
+	{
+		return true;
+	}
+
+	return false;
+}
+
+bool circular_buffer_is_full(CircularBuffer* circBuffer)
+{
+	assert(circBuffer != NULL);
+
+	return circBuffer->isFull;
+}

--- a/BufferDriver/CircularBuffer.h
+++ b/BufferDriver/CircularBuffer.h
@@ -12,7 +12,7 @@
 #else
 #if CIRCULAR_BUFFER_CAPACITY_BYTES < 1024
 #error When 'CIRCULAR_BUFFER_CAPACITY_BYTES' is specified, it must be a value greater\
-than or equal to 1024.
+ than or equal to 1024.
 #endif
 #endif
 
@@ -41,19 +41,11 @@ typedef struct
 	/**
 	 * Whether or not the circular buffer is currently empty.
 	 */
-	bool isFull;
+	bool isEmpty;
 } CircularBuffer;
 
 /**
- * Initializes the contents of a circular buffer.
- * @param bufferSize The size that the circular buffer should be.
- * @param buffer The CircularBuffer object to initialize.
- * @return True if the operation succeeds, otherwise false.
- */
-bool CircularBufferCreate(CircularBuffer* buffer);
-
-/**
- * Clears the circular buffer, emptying it of contents.
+ * Clears the circular buffer, emptying it of contents. This doubles as initialization.
  * @param buffer The CircularBuffer object to initialize.
  */
 void CircularBufferClear(CircularBuffer* buffer);
@@ -69,7 +61,8 @@ void CircularBufferClear(CircularBuffer* buffer);
 void CircularBufferAddByte(unsigned char byte, CircularBuffer* buffer);
 
 /**
- * Gets a single byte from the specified circular buffer if it isn't empty.
+ * Gets the next byte from the specified circular buffer if it isn't empty. This
+ * will remove the byte from the buffer.
  * @param buffer The CircularBuffer object to use.
  * @return The next available byte in the circular buffer.
  */
@@ -84,12 +77,14 @@ unsigned short CircularBufferCount(CircularBuffer* buffer);
 
 /**
  * Gets whether or not the circular buffer is empty.
+ * @param buffer The CircularBuffer object to use.
  * @return True if the buffer is empty, otherwise false.
  */
 bool CircularBufferIsEmpty(CircularBuffer* buffer);
 
 /**
  * Gets whether or not the circular buffer is full.
+ * @param buffer The CircularBuffer object to use.
  * @return True if the buffer is full, otherwise false.
  */
 bool CircularBufferIsFull(CircularBuffer* buffer);

--- a/BufferDriver/CircularBuffer.h
+++ b/BufferDriver/CircularBuffer.h
@@ -1,0 +1,96 @@
+
+/**
+ * @file CircularBuffer.h
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifndef CIRCULAR_BUFFER_CAPACITY_BYTES
+#define CIRCULAR_BUFFER_CAPACITY_BYTES 1024
+#else
+#if CIRCULAR_BUFFER_CAPACITY_BYTES < 1024
+#error When 'CIRCULAR_BUFFER_CAPACITY_BYTES' is specified, it must be a value greater\
+than or equal to 1024.
+#endif
+#endif
+
+/**
+ * @brief Represents a Circular Buffer of a fixed size.
+ *
+ * A circular buffer acts the way the name describes; it's a buffer of a fixed size that allows data
+ * to be added and read from it arbitrarily. The data can wrap around the bounds of the buffer.
+ * Normally we would hide the implementation details (the actual struct) in the C file, but to avoid
+ * extra mallocs, we make the internals of the struct available to clients.
+ */
+typedef struct tagCircularBuffer
+{
+	/**
+	 * The head of the circular buffer.
+	 */
+	unsigned short head;
+	/**
+	 * The tail of the circular buffer.
+	 */
+	unsigned short tail;
+	/**
+	 * The circular buffer itself.
+	 */
+	unsigned char buffer[CIRCULAR_BUFFER_CAPACITY_BYTES];
+	/**
+	 * Whether or not the circular buffer is currently empty.
+	 */
+	bool isFull;
+} CircularBuffer;
+
+/**
+ * Initializes the contents of a circular buffer.
+ * @param bufferSize The size that the circular buffer should be.
+ * @param buffer The CircularBuffer object to initialize.
+ * @return True if the operation succeeds, otherwise false.
+ */
+bool circular_buffer_create(CircularBuffer* buffer);
+
+/**
+ * Clears the circular buffer, emptying it of contents.
+ * @param buffer The CircularBuffer object to initialize.
+ */
+void circular_buffer_clear(CircularBuffer* buffer);
+
+/**
+ * Adds a single byte to the specified circular buffer. Note that if the buffer is full when this
+ * is done, the oldest data will be overwritten, and the buffer will continue being considered full
+ * until the circular_buffer_get_byte function is called.
+ *
+ * @param byte The byte to add to the circular buffer.
+ * @param buffer The CircularBuffer object to use.
+ */
+void circular_buffer_add_byte(unsigned char byte, CircularBuffer* buffer);
+
+/**
+ * Gets a single byte from the specified circular buffer if it isn't empty.
+ * @param buffer The CircularBuffer object to use.
+ * @return The next available byte in the circular buffer.
+ */
+unsigned char circular_buffer_get_byte(CircularBuffer* buffer);
+
+/**
+ * Gets the amount of data that is currently in the buffer.
+ * @param buffer The CircularBuffer object to use.
+ * @return The number of bytes that are currently in the buffer.
+ */
+unsigned short circular_buffer_count(CircularBuffer* buffer);
+
+/**
+ * Gets whether or not the circular buffer is empty.
+ * @return True if the buffer is empty, otherwise false.
+ */
+bool circular_buffer_is_empty(CircularBuffer* buffer);
+
+/**
+ * Gets whether or not the circular buffer is full.
+ * @return True if the buffer is full, otherwise false.
+ */
+bool circular_buffer_is_full(CircularBuffer* buffer);

--- a/BufferDriver/CircularBuffer.h
+++ b/BufferDriver/CircularBuffer.h
@@ -1,4 +1,3 @@
-
 /**
  * @file CircularBuffer.h
  */
@@ -20,12 +19,12 @@ than or equal to 1024.
 /**
  * @brief Represents a Circular Buffer of a fixed size.
  *
- * A circular buffer acts the way the name describes; it's a buffer of a fixed size that allows data
+ * A circular buffer acts the way the name describes; it's a buffer of fixed size that allows data
  * to be added and read from it arbitrarily. The data can wrap around the bounds of the buffer.
  * Normally we would hide the implementation details (the actual struct) in the C file, but to avoid
  * extra mallocs, we make the internals of the struct available to clients.
  */
-typedef struct tagCircularBuffer
+typedef struct
 {
 	/**
 	 * The head of the circular buffer.
@@ -51,46 +50,46 @@ typedef struct tagCircularBuffer
  * @param buffer The CircularBuffer object to initialize.
  * @return True if the operation succeeds, otherwise false.
  */
-bool circular_buffer_create(CircularBuffer* buffer);
+bool CircularBufferCreate(CircularBuffer* buffer);
 
 /**
  * Clears the circular buffer, emptying it of contents.
  * @param buffer The CircularBuffer object to initialize.
  */
-void circular_buffer_clear(CircularBuffer* buffer);
+void CircularBufferClear(CircularBuffer* buffer);
 
 /**
  * Adds a single byte to the specified circular buffer. Note that if the buffer is full when this
  * is done, the oldest data will be overwritten, and the buffer will continue being considered full
- * until the circular_buffer_get_byte function is called.
+ * until the CircularBufferGetByte function is called.
  *
  * @param byte The byte to add to the circular buffer.
  * @param buffer The CircularBuffer object to use.
  */
-void circular_buffer_add_byte(unsigned char byte, CircularBuffer* buffer);
+void CircularBufferAddByte(unsigned char byte, CircularBuffer* buffer);
 
 /**
  * Gets a single byte from the specified circular buffer if it isn't empty.
  * @param buffer The CircularBuffer object to use.
  * @return The next available byte in the circular buffer.
  */
-unsigned char circular_buffer_get_byte(CircularBuffer* buffer);
+unsigned char CircularBufferGetByte(CircularBuffer* buffer);
 
 /**
  * Gets the amount of data that is currently in the buffer.
  * @param buffer The CircularBuffer object to use.
  * @return The number of bytes that are currently in the buffer.
  */
-unsigned short circular_buffer_count(CircularBuffer* buffer);
+unsigned short CircularBufferCount(CircularBuffer* buffer);
 
 /**
  * Gets whether or not the circular buffer is empty.
  * @return True if the buffer is empty, otherwise false.
  */
-bool circular_buffer_is_empty(CircularBuffer* buffer);
+bool CircularBufferIsEmpty(CircularBuffer* buffer);
 
 /**
  * Gets whether or not the circular buffer is full.
  * @return True if the buffer is full, otherwise false.
  */
-bool circular_buffer_is_full(CircularBuffer* buffer);
+bool CircularBufferIsFull(CircularBuffer* buffer);

--- a/BufferDriver/CircularBufferTest.c
+++ b/BufferDriver/CircularBufferTest.c
@@ -2,20 +2,40 @@
  * @file CircularBufferTest.c
  */
 
-#define CIRCULAR_BUFFER_CAPACITY_BYTES 2056
-
 #include "CircularBuffer.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
 
+void CircularBufferShouldHaveNoDataAfterBeingCleared()
+{
+    CircularBuffer buffer;
+    CircularBufferClear(&buffer);
+    
+    assert(CircularBufferCount(&buffer) == 0);
+}
+
+void CircularBufferShouldReportEmptyWhenZeroBytesInBuffer()
+{
+    CircularBuffer buffer;
+    CircularBufferClear(&buffer);
+
+    for (unsigned int i = 0; i < 10; i++)
+    {
+        CircularBufferAddByte('A', &buffer);
+    }
+    for (unsigned int i = 0; i < 10; i++)
+    {
+        CircularBufferGetByte(&buffer);
+    }
+
+    assert(CircularBufferIsEmpty(&buffer));
+}
+
 void CircularBufferSizeShouldEqualNumberOfBytesInBuffer()
 {
     CircularBuffer buffer;
-    CircularBufferCreate(&buffer);
-
-    assert(!CircularBufferIsFull(&buffer));
-    assert(CircularBufferCount(&buffer) == 0);
+    CircularBufferClear(&buffer);
 
     for (unsigned int i = 0; i < 10; i++)
     {
@@ -25,24 +45,49 @@ void CircularBufferSizeShouldEqualNumberOfBytesInBuffer()
     assert(CircularBufferCount(&buffer) == 10);
 }
 
-void CircularBufferShouldReportFullWhenFull()
+void CircularBufferShouldAddAndRemoveInQueueOrder()
+{
+    static unsigned char bufferContents[7] = {'A', 'B', 'C', 'D', 'E', 'F', 'G'};
+    CircularBuffer buffer;
+    CircularBufferClear(&buffer);
+
+    for (unsigned int i = 0; i < 7; i++)
+    {
+        CircularBufferAddByte(bufferContents[i], &buffer);
+    }
+
+    for (unsigned int i = 0; i < 7; i++)
+    {
+        unsigned char letter = CircularBufferGetByte(&buffer);
+        assert(letter == bufferContents[i]);
+    }
+}
+
+void CircularBufferShouldOverwriteOldestValuesWhenAddingToFullBuffer()
 {
     CircularBuffer buffer;
-    CircularBufferCreate(&buffer);
+    CircularBufferClear(&buffer);
 
     for (unsigned int i = 0; i < CIRCULAR_BUFFER_CAPACITY_BYTES; i++)
     {
         CircularBufferAddByte('A', &buffer);
     }
 
-    assert(CircularBufferIsFull(&buffer));
+    CircularBufferAddByte('B', &buffer);
+
+    assert(CircularBufferGetByte(&buffer) == 'B');
 }
 
 int main()
 {
+    printf("Running Circular Buffer tests using buffer of size %i bytes.\n", CIRCULAR_BUFFER_CAPACITY_BYTES);
+    
     // Execute all tests.
+    CircularBufferShouldHaveNoDataAfterBeingCleared();
+    CircularBufferShouldReportEmptyWhenZeroBytesInBuffer();
     CircularBufferSizeShouldEqualNumberOfBytesInBuffer();
-    CircularBufferShouldReportFullWhenFull();
+    CircularBufferShouldAddAndRemoveInQueueOrder();
+    CircularBufferShouldOverwriteOldestValuesWhenAddingToFullBuffer();
 
     printf("All Circular Buffer tests passed.\n");
     return 0;

--- a/BufferDriver/CircularBufferTest.c
+++ b/BufferDriver/CircularBufferTest.c
@@ -1,0 +1,49 @@
+/**
+ * @file CircularBufferTest.c
+ */
+
+#define CIRCULAR_BUFFER_CAPACITY_BYTES 2056
+
+#include "CircularBuffer.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+
+void CircularBufferSizeShouldEqualNumberOfBytesInBuffer()
+{
+    CircularBuffer buffer;
+    CircularBufferCreate(&buffer);
+
+    assert(!CircularBufferIsFull(&buffer));
+    assert(CircularBufferCount(&buffer) == 0);
+
+    for (unsigned int i = 0; i < 10; i++)
+    {
+        CircularBufferAddByte('B', &buffer);
+    }
+
+    assert(CircularBufferCount(&buffer) == 10);
+}
+
+void CircularBufferShouldReportFullWhenFull()
+{
+    CircularBuffer buffer;
+    CircularBufferCreate(&buffer);
+
+    for (unsigned int i = 0; i < CIRCULAR_BUFFER_CAPACITY_BYTES; i++)
+    {
+        CircularBufferAddByte('A', &buffer);
+    }
+
+    assert(CircularBufferIsFull(&buffer));
+}
+
+int main()
+{
+    // Execute all tests.
+    CircularBufferSizeShouldEqualNumberOfBytesInBuffer();
+    CircularBufferShouldReportFullWhenFull();
+
+    printf("All Circular Buffer tests passed.\n");
+    return 0;
+}

--- a/BufferDriver/Makefile
+++ b/BufferDriver/Makefile
@@ -5,8 +5,13 @@ BufferDriver-objs := CircularBuffer.o
 
 # Compiler variables.
 CC = gcc
-CFLAGS = -std=c99
+CFLAGS = -std=c99 -g
 CFLAGS_LINK = -static
+
+# Command line variables.
+ifdef CIRCULAR_BUFFER_CAPACITY
+	CFLAGS += -DCIRCULAR_BUFFER_CAPACITY_BYTES=$(CIRCULAR_BUFFER_CAPACITY)
+endif
 
 # Other variables.
 TEST_BINARY_NAME = CircularBufferTest

--- a/BufferDriver/Makefile
+++ b/BufferDriver/Makefile
@@ -1,0 +1,27 @@
+# Change the name of this if the main object file isn't called "BufferDriver.o".
+obj-m += BufferDriver.o
+# Add other object files to this list, separated by spaces.
+BufferDriver-objs := CircularBuffer.o
+
+# Compiler variables.
+CC = gcc
+CFLAGS = -std=c99
+CFLAGS_LINK = -static
+
+# Other variables.
+TEST_BINARY_NAME = CircularBufferTest
+OBJ_PATH = obj/
+BIN_PATH = bin/
+
+all:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+
+clean:
+	make -C /lib/modules/$(shall uname -r)/build M=$(PWD) clean
+
+circ_buffer_test:
+	@mkdir -p $(OBJ_PATH) # Create the object directory if it doesn't currently exist.	
+	$(CC) $(CFLAGS) -c CircularBuffer.c -o $(OBJ_PATH)CircularBuffer.o
+	$(CC) $(CFLAGS) -c CircularBufferTest.c -o $(OBJ_PATH)CircularBufferTest.o
+	@mkdir -p $(BIN_PATH) # Create the binary directory if it doesn't currently exist.
+	$(CC) $(CFLAGS_LINK) $(OBJ_PATH)CircularBuffer.o $(OBJ_PATH)CircularBufferTest.o -o $(BIN_PATH)$(TEST_BINARY_NAME)


### PR DESCRIPTION
This will create a new directory called `BufferDriver` where a new driver Makefile is stored. I did not implement any driver code, so just running `make` on this Makefile _will result in an error_.

As I mentioned in our chat, I already implemented a circular buffer in my senior design project, so I mostly just copied and pasted it in here. I removed all dynamic allocations and made it so the buffer size is controlled by `CIRCULAR_BUFFER_CAPACITY_BYTES` directive. If not defined, it defaults to 1024 bytes. If defined, it's value must be greater than or equal to 1024.

In the interest of creating as stable of code as possible, I'm also writing tests for my code. This is mainly for my own purposes and you two can ignore everything related to the Circular Buffer tests. If either of you two _do_ wish to compile and run the test executable, you can run `make circ_buffer_tests` _from the BufferDriver directory_ to compile it, and then run it with `./bin/CircularBufferTest`. It should just print a small success message if all the tests passed.